### PR TITLE
Don't cleanup /lib/debug: it's in the debug package

### DIFF
--- a/net.sf.nootka.json
+++ b/net.sf.nootka.json
@@ -38,7 +38,6 @@
           "/bin",
           "/include",
           "/lib/pkgconfig",
-          "/lib/debug",
           "/share/aclocal",
           "/share/doc"
       ]
@@ -66,7 +65,6 @@
       "cleanup": [
           "/share/doc",
           "/share/man",
-          "/lib/debug",
           "/share/pixmaps"
       ]
     }


### PR DESCRIPTION
 I noticed `/lib/debug` was cleaned up, but it shouldn't. It's part of the `.Debug` package that can be used to have debug symbols.